### PR TITLE
Adding '$ python manage.py migrate' to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This will provision an entire setup for you pretty quickly (see `provision/dev/b
 $ vagrant ssh
 $ cd /vagrant/tock
 $ pyenv activate tock
+$ python manage.py migrate
 $ python manage.py runserver
 ```
 


### PR DESCRIPTION
Decided to take a look after reading 18F's blog post. I don't have any Vagrant/Django experience and was encountering two "ProgrammingError" issues from the very start.  Running '$ python manage.py migrate' prior to the '$ python manage.py runserver' command solved this for me. 

ProgrammingErrors consisted of ["relation "auth_user" does not exist"] on tock page and ["relation "projects_accountingcode" does not exist"] on admin page.